### PR TITLE
Fixed build error in Xcode 7.1 (7B91b)

### DIFF
--- a/CEF3SimpleSample.xcodeproj/project.pbxproj
+++ b/CEF3SimpleSample.xcodeproj/project.pbxproj
@@ -507,7 +507,7 @@
 					"$(PROJECT_DIR)/CEF3SimpleSample/CEF/Mac/Release",
 					"$(PROJECT_DIR)/CEF3SimpleSample/CEF/Mac/lib",
 				);
-				OTHER_LDFLAGS = "";
+				OTHER_LDFLAGS = "-headerpad_max_install_names";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -535,7 +535,7 @@
 					"$(PROJECT_DIR)/CEF3SimpleSample/CEF/Mac/Release",
 					"$(PROJECT_DIR)/CEF3SimpleSample/CEF/Mac/lib",
 				);
-				OTHER_LDFLAGS = "";
+				OTHER_LDFLAGS = "-headerpad_max_install_names";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;


### PR DESCRIPTION
Fix for the following build error that happens in Xcode 7.1 (7B91b):
error: install_name_tool: changing install names or rpaths can't be redone for: /Users/.../Build/Products/Debug/CEF3 Simple Sample.app/Contents/MacOS/CEF3 Simple Sample (for architecture x86_64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)